### PR TITLE
Add static bridge for strings

### DIFF
--- a/ros2_ign_bridge/CMakeLists.txt
+++ b/ros2_ign_bridge/CMakeLists.txt
@@ -11,5 +11,47 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(std_msgs REQUIRED)
+
+find_package(ignition-msgs4 QUIET REQUIRED)
+set(IGN_MSGS_VER ${ignition-msgs4_VERSION_MAJOR})
+
+find_package(ignition-transport7 QUIET REQUIRED)
+set(IGN_TRANSPORT_VER ${ignition-transport7_VERSION_MAJOR})
+
+include_directories(include)
+
+set(common_sources
+  src/convert_builtin_interfaces.cpp
+  src/builtin_interfaces_factories.cpp
+)
+
+set(bridge_executables
+  static_bridge
+)
+
+foreach(bridge ${bridge_executables})
+  add_executable(${bridge}
+    src/${bridge}.cpp
+    ${common_sources}
+  )
+  target_link_libraries(${bridge}
+    ignition-msgs${IGN_MSGS_VER}::core
+    ignition-transport${IGN_TRANSPORT_VER}::core
+  )
+  ament_target_dependencies(${bridge}
+    "rclcpp"
+    "std_msgs"
+  )
+  install(TARGETS ${bridge}
+    DESTINATION lib/${PROJECT_NAME}
+  )
+endforeach()
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
 ament_package()

--- a/ros2_ign_bridge/README.md
+++ b/ros2_ign_bridge/README.md
@@ -8,7 +8,7 @@ service calls. Its support is limited to only the following message types:
 
 | ROS 2 type                     | Ignition Transport type          |
 |--------------------------------|:--------------------------------:|
-| TODO                           | TODO                             |
+| std_msgs/msg/String            | ignition::msgs::StringMsg        |
 
 ## Prerequisites
 
@@ -53,3 +53,41 @@ TODO
 ## Example 2: Run the bridge and exchange images
 
 TODO
+
+## Example 3: Static bridge
+
+In this example, we're going to run an executable that starts a bidirectional
+bridge for a specific topic and message type. We'll use the `static_bridge`
+executable that is installed with the bridge.
+
+The example's code can be found under `ros2_ign_bridge/src/static_bridge.cpp`.
+In the code, it's possible to see how the bridge is hardcoded to bridge string
+messages published on the `/chatter` topic.
+
+Let's give it a try, starting with Ignition -> ROS 2.
+
+On terminal A, start the bridge:
+
+`ros2 run ros2_ign_bridge static_bridge`
+
+On terminal B, we start a ROS 2 listener:
+
+`ros2 topic echo /chatter std_msgs/msg/String`
+
+And terminal C, publish an Ignition message:
+
+`ign topic pub -t /chatter -m ignition.msgs.StringMsg -p 'data:"Hello"'`
+
+At this point, you should see the ROS 2 listener echoing the message.
+
+Now let's try the other way around, ROS 2 -> Ignition.
+
+On terminal D, start an Igntion listener:
+
+`ign topic -e -t /chatter`
+
+And on terminal E, publish a ROS 2 message:
+
+`ros2 topic pub /chatter std_msgs/msg/String 'data: "Hello"' -1`
+
+You should see the Ignition listener echoing the message.

--- a/ros2_ign_bridge/include/ros2_ign_bridge/bridge.hpp
+++ b/ros2_ign_bridge/include/ros2_ign_bridge/bridge.hpp
@@ -51,12 +51,13 @@ create_bridge_from_ros2_to_ign(
   const std::string & ros2_type_name,
   const std::string & ros2_topic_name,
   const std::string & ign_type_name,
-  const std::string & ign_topic_name)
+  const std::string & ign_topic_name,
+  size_t queue_size)
 {
   auto factory = get_factory(ros2_type_name, ign_type_name);
   auto ign_pub = factory->create_ign_publisher(ign_node, ign_topic_name);
 
-  auto ros2_sub = factory->create_ros2_subscriber(ros2_node, ros2_topic_name, ign_pub);
+  auto ros2_sub = factory->create_ros2_subscriber(ros2_node, ros2_topic_name, queue_size, ign_pub);
 
   BridgeRos2toIgnHandles handles;
   handles.ros2_subscriber = ros2_sub;
@@ -71,10 +72,11 @@ create_bridge_from_ign_to_ros2(
   const std::string & ign_type_name,
   const std::string & ign_topic_name,
   const std::string & ros2_type_name,
-  const std::string & ros2_topic_name)
+  const std::string & ros2_topic_name,
+  size_t queue_size)
 {
   auto factory = get_factory(ros2_type_name, ign_type_name);
-  auto ros2_pub = factory->create_ros2_publisher(ros2_node, ros2_topic_name);
+  auto ros2_pub = factory->create_ros2_publisher(ros2_node, ros2_topic_name, queue_size);
 
   factory->create_ign_subscriber(ign_node, ign_topic_name, ros2_pub);
 
@@ -90,15 +92,16 @@ create_bidirectional_bridge(
   std::shared_ptr<ignition::transport::Node> ign_node,
   const std::string & ros2_type_name,
   const std::string & ign_type_name,
-  const std::string & topic_name)
+  const std::string & topic_name,
+  size_t queue_size = 10)
 {
   BridgeHandles handles;
   handles.bridgeRos2toIgn = create_bridge_from_ros2_to_ign(
     ros2_node, ign_node,
-    ros2_type_name, topic_name, ign_type_name, topic_name);
+    ros2_type_name, topic_name, ign_type_name, topic_name, queue_size);
   handles.bridgeIgntoRos2 = create_bridge_from_ign_to_ros2(
     ign_node, ros2_node,
-    ign_type_name, topic_name, ros2_type_name, topic_name);
+    ign_type_name, topic_name, ros2_type_name, topic_name, queue_size);
   return handles;
 }
 

--- a/ros2_ign_bridge/include/ros2_ign_bridge/bridge.hpp
+++ b/ros2_ign_bridge/include/ros2_ign_bridge/bridge.hpp
@@ -1,0 +1,107 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROS2_IGN_BRIDGE__BRIDGE_HPP_
+#define ROS2_IGN_BRIDGE__BRIDGE_HPP_
+
+// include Ignition Transport
+#include <ignition/transport/Node.hh>
+
+#include <ros2_ign_bridge/builtin_interfaces_factories.hpp>
+
+#include <memory>
+#include <string>
+
+namespace ros2_ign_bridge
+{
+
+struct BridgeRos2toIgnHandles
+{
+  rclcpp::SubscriptionBase::SharedPtr ros2_subscriber;
+  ignition::transport::Node::Publisher ign_publisher;
+};
+
+struct BridgeIgntoRos2Handles
+{
+  std::shared_ptr<ignition::transport::Node> ign_subscriber;
+  rclcpp::PublisherBase::SharedPtr ros2_publisher;
+};
+
+struct BridgeHandles
+{
+  BridgeRos2toIgnHandles bridgeRos2toIgn;
+  BridgeIgntoRos2Handles bridgeIgntoRos2;
+};
+
+BridgeRos2toIgnHandles
+create_bridge_from_ros2_to_ign(
+  rclcpp::Node::SharedPtr ros2_node,
+  std::shared_ptr<ignition::transport::Node> ign_node,
+  const std::string & ros2_type_name,
+  const std::string & ros2_topic_name,
+  const std::string & ign_type_name,
+  const std::string & ign_topic_name)
+{
+  auto factory = get_factory(ros2_type_name, ign_type_name);
+  auto ign_pub = factory->create_ign_publisher(ign_node, ign_topic_name);
+
+  auto ros2_sub = factory->create_ros2_subscriber(ros2_node, ros2_topic_name, ign_pub);
+
+  BridgeRos2toIgnHandles handles;
+  handles.ros2_subscriber = ros2_sub;
+  handles.ign_publisher = ign_pub;
+  return handles;
+}
+
+BridgeIgntoRos2Handles
+create_bridge_from_ign_to_ros2(
+  std::shared_ptr<ignition::transport::Node> ign_node,
+  rclcpp::Node::SharedPtr ros2_node,
+  const std::string & ign_type_name,
+  const std::string & ign_topic_name,
+  const std::string & ros2_type_name,
+  const std::string & ros2_topic_name)
+{
+  auto factory = get_factory(ros2_type_name, ign_type_name);
+  auto ros2_pub = factory->create_ros2_publisher(ros2_node, ros2_topic_name);
+
+  factory->create_ign_subscriber(ign_node, ign_topic_name, ros2_pub);
+
+  BridgeIgntoRos2Handles handles;
+  handles.ign_subscriber = ign_node;
+  handles.ros2_publisher = ros2_pub;
+  return handles;
+}
+
+BridgeHandles
+create_bidirectional_bridge(
+  rclcpp::Node::SharedPtr ros2_node,
+  std::shared_ptr<ignition::transport::Node> ign_node,
+  const std::string & ros2_type_name,
+  const std::string & ign_type_name,
+  const std::string & topic_name)
+{
+  BridgeHandles handles;
+  handles.bridgeRos2toIgn = create_bridge_from_ros2_to_ign(
+    ros2_node, ign_node,
+    ros2_type_name, topic_name, ign_type_name, topic_name);
+  handles.bridgeIgntoRos2 = create_bridge_from_ign_to_ros2(
+    ign_node, ros2_node,
+    ign_type_name, topic_name, ros2_type_name, topic_name);
+  return handles;
+}
+
+}  // namespace ros2_ign_bridge
+
+#endif  // ROS2_IGN_BRIDGE__BRIDGE_HPP_

--- a/ros2_ign_bridge/include/ros2_ign_bridge/builtin_interfaces_factories.hpp
+++ b/ros2_ign_bridge/include/ros2_ign_bridge/builtin_interfaces_factories.hpp
@@ -1,0 +1,65 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROS2_IGN_BRIDGE__BUILTIN_INTERFACES_FACTORIES_HPP_
+#define ROS2_IGN_BRIDGE__BUILTIN_INTERFACES_FACTORIES_HPP_
+
+// include ROS 2 messages
+#include <std_msgs/msg/string.hpp>
+
+// include Ignition Transport messages
+#include <ignition/msgs.hh>
+
+#include <ros2_ign_bridge/factory.hpp>
+
+#include <memory>
+#include <string>
+
+namespace ros2_ign_bridge
+{
+
+std::shared_ptr<FactoryInterface>
+get_factory_builtin_interfaces(
+  const std::string & ros2_type_name,
+  const std::string & ign_type_name);
+
+std::shared_ptr<FactoryInterface>
+get_factory(
+  const std::string & ros2_type_name,
+  const std::string & ign_type_name);
+
+// conversion functions for available interfaces
+
+// std_msgs
+template<>
+void
+Factory<
+  std_msgs::msg::String,
+  ignition::msgs::StringMsg
+>::convert_ros2_to_ign(
+  const std_msgs::msg::String & ros2_msg,
+  ignition::msgs::StringMsg & ign_msg);
+
+template<>
+void
+Factory<
+  std_msgs::msg::String,
+  ignition::msgs::StringMsg
+>::convert_ign_to_ros2(
+  const ignition::msgs::StringMsg & ign_msg,
+  std_msgs::msg::String & ros2_msg);
+
+}  // namespace ros2_ign_bridge
+
+#endif  // ROS2_IGN_BRIDGE__BUILTIN_INTERFACES_FACTORIES_HPP_

--- a/ros2_ign_bridge/include/ros2_ign_bridge/convert_builtin_interfaces.hpp
+++ b/ros2_ign_bridge/include/ros2_ign_bridge/convert_builtin_interfaces.hpp
@@ -1,0 +1,44 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROS2_IGN_BRIDGE__CONVERT_BUILTIN_INTERFACES_HPP_
+#define ROS2_IGN_BRIDGE__CONVERT_BUILTIN_INTERFACES_HPP_
+
+// include ROS 2 builtin messages
+#include <std_msgs/msg/string.hpp>
+
+// include Ignition builtin messages
+#include <ignition/msgs.hh>
+
+#include <ros2_ign_bridge/convert_decl.hpp>
+
+namespace ros2_ign_bridge
+{
+
+// std_msgs
+template<>
+void
+convert_ros2_to_ign(
+  const std_msgs::msg::String & ros2_msg,
+  ignition::msgs::StringMsg & ign_msg);
+
+template<>
+void
+convert_ign_to_ros2(
+  const ignition::msgs::StringMsg & ign_msg,
+  std_msgs::msg::String & ros2_msg);
+
+}  // namespace ros2_ign_bridge
+
+#endif  // ROS2_IGN_BRIDGE__CONVERT_BUILTIN_INTERFACES_HPP_

--- a/ros2_ign_bridge/include/ros2_ign_bridge/convert_decl.hpp
+++ b/ros2_ign_bridge/include/ros2_ign_bridge/convert_decl.hpp
@@ -1,0 +1,35 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROS2_IGN_BRIDGE__CONVERT_DECL_HPP_
+#define ROS2_IGN_BRIDGE__CONVERT_DECL_HPP_
+
+namespace ros2_ign_bridge
+{
+
+template<typename ROS2_T, typename IGN_T>
+void
+convert_ros2_to_ign(
+  const ROS2_T & ros2_msg,
+  IGN_T & ign_msg);
+
+template<typename ROS2_T, typename IGN_T>
+void
+convert_ign_to_ros2(
+  const IGN_T & ign_msg,
+  ROS2_T & ros2_msg);
+
+}  // namespace ros2_ign_bridge
+
+#endif  // ROS2_IGN_BRIDGE__CONVERT_DECL_HPP_

--- a/ros2_ign_bridge/include/ros2_ign_bridge/factory.hpp
+++ b/ros2_ign_bridge/include/ros2_ign_bridge/factory.hpp
@@ -42,10 +42,11 @@ public:
   rclcpp::PublisherBase::SharedPtr
   create_ros2_publisher(
     rclcpp::Node::SharedPtr ros2_node,
-    const std::string & topic_name)
+    const std::string & topic_name,
+    size_t queue_size)
   {
     std::shared_ptr<rclcpp::Publisher<ROS2_T>> publisher =
-      ros2_node->create_publisher<ROS2_T>(topic_name, rclcpp::QoS(rclcpp::KeepLast(1)));
+      ros2_node->create_publisher<ROS2_T>(topic_name, rclcpp::QoS(rclcpp::KeepLast(queue_size)));
     return publisher;
   }
 
@@ -61,12 +62,14 @@ public:
   create_ros2_subscriber(
     rclcpp::Node::SharedPtr ros2_node,
     const std::string & topic_name,
+    size_t queue_size,
     ignition::transport::Node::Publisher & ign_pub)
   {
     std::function<void(std::shared_ptr<const ROS2_T>)> fn =
       std::bind(&Factory<ROS2_T, IGN_T>::ros2_callback, std::placeholders::_1, ign_pub);
     std::shared_ptr<rclcpp::Subscription<ROS2_T>> subscription =
-      ros2_node->create_subscription<ROS2_T>(topic_name, rclcpp::QoS(rclcpp::KeepLast(1)), fn);
+      ros2_node->create_subscription<ROS2_T>(
+      topic_name, rclcpp::QoS(rclcpp::KeepLast(queue_size)), fn);
     return subscription;
   }
 

--- a/ros2_ign_bridge/include/ros2_ign_bridge/factory.hpp
+++ b/ros2_ign_bridge/include/ros2_ign_bridge/factory.hpp
@@ -1,0 +1,136 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROS2_IGN_BRIDGE__FACTORY_HPP_
+#define ROS2_IGN_BRIDGE__FACTORY_HPP_
+
+#include <ignition/transport/Node.hh>
+
+// include ROS 2
+#include <rclcpp/rclcpp.hpp>
+
+#include <ros2_ign_bridge/factory_interface.hpp>
+
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace ros2_ign_bridge
+{
+
+template<typename ROS2_T, typename IGN_T>
+class Factory : public FactoryInterface
+{
+public:
+  Factory(
+    const std::string & ros2_type_name, const std::string & ign_type_name)
+  : ros2_type_name_(ros2_type_name),
+    ign_type_name_(ign_type_name)
+  {}
+
+  rclcpp::PublisherBase::SharedPtr
+  create_ros2_publisher(
+    rclcpp::Node::SharedPtr ros2_node,
+    const std::string & topic_name)
+  {
+    std::shared_ptr<rclcpp::Publisher<ROS2_T>> publisher =
+      ros2_node->create_publisher<ROS2_T>(topic_name, rclcpp::QoS(rclcpp::KeepLast(1)));
+    return publisher;
+  }
+
+  ignition::transport::Node::Publisher
+  create_ign_publisher(
+    std::shared_ptr<ignition::transport::Node> ign_node,
+    const std::string & topic_name)
+  {
+    return ign_node->Advertise<IGN_T>(topic_name);
+  }
+
+  rclcpp::SubscriptionBase::SharedPtr
+  create_ros2_subscriber(
+    rclcpp::Node::SharedPtr ros2_node,
+    const std::string & topic_name,
+    ignition::transport::Node::Publisher & ign_pub)
+  {
+    std::function<void(std::shared_ptr<const ROS2_T>)> fn =
+      std::bind(&Factory<ROS2_T, IGN_T>::ros2_callback, std::placeholders::_1, ign_pub);
+    std::shared_ptr<rclcpp::Subscription<ROS2_T>> subscription =
+      ros2_node->create_subscription<ROS2_T>(topic_name, rclcpp::QoS(rclcpp::KeepLast(1)), fn);
+    return subscription;
+  }
+
+  void
+  create_ign_subscriber(
+    std::shared_ptr<ignition::transport::Node> node,
+    const std::string & topic_name,
+    rclcpp::PublisherBase::SharedPtr ros2_pub)
+  {
+    std::function<void(const IGN_T &,
+      const ignition::transport::MessageInfo &)> subCb =
+      [this, ros2_pub](const IGN_T & _msg,
+        const ignition::transport::MessageInfo & _info)
+      {
+        // Ignore messages that are published from this bridge.
+        if (!_info.IntraProcess()) {
+          this->ign_callback(_msg, ros2_pub);
+        }
+      };
+
+    node->Subscribe(topic_name, subCb);
+  }
+
+protected:
+  static
+  void ros2_callback(
+    std::shared_ptr<const ROS2_T> ros2_msg,
+    ignition::transport::Node::Publisher & ign_pub)
+  {
+    IGN_T ign_msg;
+    convert_ros2_to_ign(*ros2_msg, ign_msg);
+    ign_pub.Publish(ign_msg);
+  }
+
+  static
+  void ign_callback(
+    const IGN_T & ign_msg,
+    rclcpp::PublisherBase::SharedPtr ros2_pub)
+  {
+    ROS2_T ros2_msg;
+    convert_ign_to_ros2(ign_msg, ros2_msg);
+    std::shared_ptr<rclcpp::Publisher<ROS2_T>> pub =
+      std::dynamic_pointer_cast<rclcpp::Publisher<ROS2_T>>(ros2_pub);
+    pub->publish(ros2_msg);
+  }
+
+public:
+  // since convert functions call each other for sub messages they must be
+  // public defined outside of the class
+  static
+  void
+  convert_ros2_to_ign(
+    const ROS2_T & ros2_msg,
+    IGN_T & ign_msg);
+  static
+  void
+  convert_ign_to_ros2(
+    const IGN_T & ign_msg,
+    ROS2_T & ros2_msg);
+
+  std::string ros2_type_name_;
+  std::string ign_type_name_;
+};
+
+}  // namespace ros2_ign_bridge
+
+#endif  // ROS2_IGN_BRIDGE__FACTORY_HPP_

--- a/ros2_ign_bridge/include/ros2_ign_bridge/factory_interface.hpp
+++ b/ros2_ign_bridge/include/ros2_ign_bridge/factory_interface.hpp
@@ -1,0 +1,62 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef  ROS2_IGN_BRIDGE__FACTORY_INTERFACE_HPP_
+#define  ROS2_IGN_BRIDGE__FACTORY_INTERFACE_HPP_
+
+// include ROS 2
+#include <rclcpp/rclcpp.hpp>
+
+// include Ignition Transport
+#include <ignition/transport/Node.hh>
+
+#include <memory>
+#include <string>
+
+namespace ros2_ign_bridge
+{
+
+class FactoryInterface
+{
+public:
+  virtual
+  rclcpp::PublisherBase::SharedPtr
+  create_ros2_publisher(
+    rclcpp::Node::SharedPtr ros2_node,
+    const std::string & topic_name) = 0;
+
+  virtual
+  ignition::transport::Node::Publisher
+  create_ign_publisher(
+    std::shared_ptr<ignition::transport::Node> ign_node,
+    const std::string & topic_name) = 0;
+
+  virtual
+  rclcpp::SubscriptionBase::SharedPtr
+  create_ros2_subscriber(
+    rclcpp::Node::SharedPtr ros2_node,
+    const std::string & topic_name,
+    ignition::transport::Node::Publisher & ign_pub) = 0;
+
+  virtual
+  void
+  create_ign_subscriber(
+    std::shared_ptr<ignition::transport::Node> node,
+    const std::string & topic_name,
+    rclcpp::PublisherBase::SharedPtr ros2_pub) = 0;
+};
+
+}  // namespace ros2_ign_bridge
+
+#endif  // ROS2_IGN_BRIDGE__FACTORY_INTERFACE_HPP_

--- a/ros2_ign_bridge/include/ros2_ign_bridge/factory_interface.hpp
+++ b/ros2_ign_bridge/include/ros2_ign_bridge/factory_interface.hpp
@@ -34,7 +34,8 @@ public:
   rclcpp::PublisherBase::SharedPtr
   create_ros2_publisher(
     rclcpp::Node::SharedPtr ros2_node,
-    const std::string & topic_name) = 0;
+    const std::string & topic_name,
+    size_t queue_size) = 0;
 
   virtual
   ignition::transport::Node::Publisher
@@ -47,6 +48,7 @@ public:
   create_ros2_subscriber(
     rclcpp::Node::SharedPtr ros2_node,
     const std::string & topic_name,
+    size_t queue_size,
     ignition::transport::Node::Publisher & ign_pub) = 0;
 
   virtual

--- a/ros2_ign_bridge/package.xml
+++ b/ros2_ign_bridge/package.xml
@@ -18,9 +18,6 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
-
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/ros2_ign_bridge/package.xml
+++ b/ros2_ign_bridge/package.xml
@@ -1,15 +1,22 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<package format="3">
   <name>ros2_ign_bridge</name>
   <version>0.1.0</version>
   <description>Bridge communication between ROS 2 and Ignition Transport</description>
-  <license>Apache 2.0</license>
   <maintainer email="louise@openrobotics.org">Louise Poubel</maintainer>
+
+  <license>Apache 2.0</license>
+
+  <author>Shivesh Khaitan</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>rclcpp</depend>
+  <depend>std_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/ros2_ign_bridge/src/builtin_interfaces_factories.cpp
+++ b/ros2_ign_bridge/src/builtin_interfaces_factories.cpp
@@ -29,7 +29,7 @@ get_factory_builtin_interfaces(
 {
   // mapping from string to specialized template
   if (
-    (ros2_type_name == "std_msgs/String" || ros2_type_name == "") &&
+    (ros2_type_name == "std_msgs/msg/String" || ros2_type_name == "") &&
     ign_type_name == "ignition.msgs.StringMsg")
   {
     return std::make_shared<
@@ -37,7 +37,7 @@ get_factory_builtin_interfaces(
         std_msgs::msg::String,
         ignition::msgs::StringMsg
       >
-    >("std_msgs/String", ign_type_name);
+    >("std_msgs/msg/String", ign_type_name);
   }
   return std::shared_ptr<FactoryInterface>();
 }

--- a/ros2_ign_bridge/src/builtin_interfaces_factories.cpp
+++ b/ros2_ign_bridge/src/builtin_interfaces_factories.cpp
@@ -1,0 +1,86 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <string>
+
+// include builtin interfaces
+#include "ros2_ign_bridge/builtin_interfaces_factories.hpp"
+#include "ros2_ign_bridge/convert_builtin_interfaces.hpp"
+
+namespace ros2_ign_bridge
+{
+
+std::shared_ptr<FactoryInterface>
+get_factory_builtin_interfaces(
+  const std::string & ros2_type_name,
+  const std::string & ign_type_name)
+{
+  // mapping from string to specialized template
+  if (
+    (ros2_type_name == "std_msgs/String" || ros2_type_name == "") &&
+    ign_type_name == "ignition.msgs.StringMsg")
+  {
+    return std::make_shared<
+      Factory<
+        std_msgs::msg::String,
+        ignition::msgs::StringMsg
+      >
+    >("std_msgs/String", ign_type_name);
+  }
+  return std::shared_ptr<FactoryInterface>();
+}
+
+std::shared_ptr<FactoryInterface>
+get_factory(
+  const std::string & ros2_type_name,
+  const std::string & ign_type_name)
+{
+  std::shared_ptr<FactoryInterface> factory;
+  factory = get_factory_builtin_interfaces(ros2_type_name, ign_type_name);
+  if (factory) {
+    return factory;
+  }
+
+  throw std::runtime_error("No template specialization for the pair");
+}
+
+// conversion functions for available interfaces
+
+// std_msgs
+template<>
+void
+Factory<
+  std_msgs::msg::String,
+  ignition::msgs::StringMsg
+>::convert_ros2_to_ign(
+  const std_msgs::msg::String & ros2_msg,
+  ignition::msgs::StringMsg & ign_msg)
+{
+  ros2_ign_bridge::convert_ros2_to_ign(ros2_msg, ign_msg);
+}
+
+template<>
+void
+Factory<
+  std_msgs::msg::String,
+  ignition::msgs::StringMsg
+>::convert_ign_to_ros2(
+  const ignition::msgs::StringMsg & ign_msg,
+  std_msgs::msg::String & ros2_msg)
+{
+  ros2_ign_bridge::convert_ign_to_ros2(ign_msg, ros2_msg);
+}
+
+}  // namespace ros2_ign_bridge

--- a/ros2_ign_bridge/src/convert_builtin_interfaces.cpp
+++ b/ros2_ign_bridge/src/convert_builtin_interfaces.cpp
@@ -1,0 +1,37 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ros2_ign_bridge/convert_builtin_interfaces.hpp>
+
+namespace ros2_ign_bridge
+{
+template<>
+void
+convert_ros2_to_ign(
+  const std_msgs::msg::String & ros2_msg,
+  ignition::msgs::StringMsg & ign_msg)
+{
+  ign_msg.set_data(ros2_msg.data);
+}
+
+template<>
+void
+convert_ign_to_ros2(
+  const ignition::msgs::StringMsg & ign_msg,
+  std_msgs::msg::String & ros2_msg)
+{
+  ros2_msg.data = ign_msg.data();
+}
+
+}  // namespace ros2_ign_bridge

--- a/ros2_ign_bridge/src/static_bridge.cpp
+++ b/ros2_ign_bridge/src/static_bridge.cpp
@@ -1,0 +1,47 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <rclcpp/rclcpp.hpp>
+
+// include Ignition Transport
+#include <ignition/transport/Node.hh>
+
+#include <ros2_ign_bridge/bridge.hpp>
+
+#include <memory>
+#include <string>
+
+//////////////////////////////////////////////////
+int main(int argc, char * argv[])
+{
+  // ROS 2 node
+  rclcpp::init(argc, argv);
+  auto ros2_node = std::make_shared<rclcpp::Node>("test_node");
+
+  // Ignition node
+  auto ign_node = std::make_shared<ignition::transport::Node>();
+
+  // bridge one example topic
+  std::string topic_name = "chatter";
+  std::string ros2_type_name = "std_msgs/String";
+  std::string ign_type_name = "ignition.msgs.StringMsg";
+
+  auto handles = ros2_ign_bridge::create_bidirectional_bridge(
+    ros2_node, ign_node, ros2_type_name, ign_type_name, topic_name);
+
+  // Wait for ign node shutdown
+  ignition::transport::waitForShutdown();
+
+  return 0;
+}

--- a/ros2_ign_bridge/src/static_bridge.cpp
+++ b/ros2_ign_bridge/src/static_bridge.cpp
@@ -36,9 +36,10 @@ int main(int argc, char * argv[])
   std::string topic_name = "chatter";
   std::string ros2_type_name = "std_msgs/msg/String";
   std::string ign_type_name = "ignition.msgs.StringMsg";
+  size_t queue_size = 10;
 
   auto handles = ros2_ign_bridge::create_bidirectional_bridge(
-    ros2_node, ign_node, ros2_type_name, ign_type_name, topic_name);
+    ros2_node, ign_node, ros2_type_name, ign_type_name, topic_name, queue_size);
 
   rclcpp::spin(ros2_node);
 

--- a/ros2_ign_bridge/src/static_bridge.cpp
+++ b/ros2_ign_bridge/src/static_bridge.cpp
@@ -34,11 +34,13 @@ int main(int argc, char * argv[])
 
   // bridge one example topic
   std::string topic_name = "chatter";
-  std::string ros2_type_name = "std_msgs/String";
+  std::string ros2_type_name = "std_msgs/msg/String";
   std::string ign_type_name = "ignition.msgs.StringMsg";
 
   auto handles = ros2_ign_bridge::create_bidirectional_bridge(
     ros2_node, ign_node, ros2_type_name, ign_type_name, topic_name);
+
+  rclcpp::spin(ros2_node);
 
   // Wait for ign node shutdown
   ignition::transport::waitForShutdown();


### PR DESCRIPTION
This adds a basic bridge for string messages.

To create the bridge
1) `ros2 run ros2_ign_bridge static_bridge`
2) Open an instance of `ign gazebo`
3) Create an ignition string msg publisher on topic `chatter`
4) `ros2 topic echo /chatter` 
